### PR TITLE
Fix debug/last viewed logic

### DIFF
--- a/app/js/decode-the-word-quiz.js
+++ b/app/js/decode-the-word-quiz.js
@@ -15,10 +15,16 @@ function getStoryId() {
     return parseInt(urlStoryId || sessionStoryId) || 1;
 }
 
+// Get current user ID (falls back to lastUserId)
+function getUserId() {
+  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
+  return currentUser?.id || parseInt(localStorage.getItem('lastUserId')) || 'guest';
+}
+
 // Check for saved quiz progress
 function getSavedQuizProgress() {
   const storyId = getStoryId();
-  const savedProgress = localStorage.getItem(`quiz2_progress_${storyId}`);
+  const savedProgress = localStorage.getItem(`quiz2_progress_${getUserId()}_${storyId}`);
   if (savedProgress) {
     try {
       return JSON.parse(savedProgress);
@@ -33,7 +39,7 @@ function getSavedQuizProgress() {
 // Save quiz progress to localStorage
 function saveQuizProgress(questionIndex, score, answers) {
   const storyId = getStoryId();
-  localStorage.setItem(`quiz2_progress_${storyId}`, JSON.stringify({
+  localStorage.setItem(`quiz2_progress_${getUserId()}_${storyId}`, JSON.stringify({
     questionIndex: questionIndex,
     score: score,
     answers: answers,
@@ -86,7 +92,7 @@ function startAgain() {
   hideResumeModal();
 
   const storyId = getStoryId();
-  localStorage.removeItem(`quiz2_progress_${storyId}`);
+  localStorage.removeItem(`quiz2_progress_${getUserId()}_${storyId}`);
 
   // Reset state
   currentQuestionIndex = 0;
@@ -288,14 +294,9 @@ function showFeedback(isCorrect, explanation) {
 }
 
 // Calculate badge type based on score
+// Quiz 2: perfect score = gold, anything less = bronze
 function calculateBadgeType(score, total) {
-    if (score === total) {
-        return 'gold';
-    } else if (score >= 3 && score <= 4) {
-        return 'silver';
-    } else {
-        return 'bronze';
-    }
+    return score === total ? 'gold' : 'bronze';
 }
 
 // Finish quiz
@@ -304,7 +305,7 @@ function finishQuiz() {
     const storyId = getStoryId();
     
     // Clear saved progress since quiz is complete
-    localStorage.removeItem(`quiz2_progress_${storyId}`);
+    localStorage.removeItem(`quiz2_progress_${getUserId()}_${storyId}`);
     
     // Store quiz results with badge type
     sessionStorage.setItem('quiz2Results', JSON.stringify({

--- a/app/js/pick-a-word-quiz.js
+++ b/app/js/pick-a-word-quiz.js
@@ -185,7 +185,7 @@ function loadQuestion(index) {
         const button = document.createElement("button");
         button.className = "start-button";
      
-        button.textContent = `$${option}`;
+        button.textContent = `${option}`;
 
         button.onclick = () => checkAnswer(idx);
         buttonsContainer.appendChild(button);

--- a/app/js/pick-a-word-quiz.js
+++ b/app/js/pick-a-word-quiz.js
@@ -15,10 +15,16 @@ function getStoryId() {
   return parseInt(urlStoryId || sessionStoryId) || 1;
 }
 
+// Get current user ID (falls back to lastUserId)
+function getUserId() {
+  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
+  return currentUser?.id || parseInt(localStorage.getItem('lastUserId')) || 'guest';
+}
+
 // Check for saved quiz progress
 function getSavedQuizProgress() {
   const storyId = getStoryId();
-  const savedProgress = localStorage.getItem(`quiz1_progress_${storyId}`);
+  const savedProgress = localStorage.getItem(`quiz1_progress_${getUserId()}_${storyId}`);
   if (savedProgress) {
     try {
       return JSON.parse(savedProgress);
@@ -33,7 +39,7 @@ function getSavedQuizProgress() {
 // Save quiz progress to localStorage
 function saveQuizProgress(questionIndex, score, answers) {
   const storyId = getStoryId();
-  localStorage.setItem(`quiz1_progress_${storyId}`, JSON.stringify({
+  localStorage.setItem(`quiz1_progress_${getUserId()}_${storyId}`, JSON.stringify({
     questionIndex: questionIndex,
     score: score,
     answers: answers,
@@ -86,7 +92,7 @@ function startAgain() {
   hideResumeModal();
 
   const storyId = getStoryId();
-  localStorage.removeItem(`quiz1_progress_${storyId}`);
+  localStorage.removeItem(`quiz1_progress_${getUserId()}_${storyId}`);
 
   // Reset state
   currentQuestionIndex = 0;
@@ -285,14 +291,9 @@ function showFeedback(isCorrect, explanation) {
 }
 
 // Calculate badge type based on score
+// Quiz 1: perfect score = silver, anything less = bronze
 function calculateBadgeType(score, total) {
-  if (score === total) {
-    return "gold";
-  } else if (score >= 3 && score <= 4) {
-    return "silver";
-  } else {
-    return "bronze";
-  }
+  return score === total ? 'silver' : 'bronze';
 }
 
 // Finish quiz
@@ -301,7 +302,7 @@ function finishQuiz() {
   const storyId = getStoryId();
 
   // Clear saved progress since quiz is complete
-  localStorage.removeItem(`quiz1_progress_${storyId}`);
+  localStorage.removeItem(`quiz1_progress_${getUserId()}_${storyId}`);
 
   // Store quiz results with badge type
   sessionStorage.setItem(

--- a/app/pages/components/resume-modal.html
+++ b/app/pages/components/resume-modal.html
@@ -29,12 +29,20 @@ function handleResumeModalOverlayClick(event) {
 
 // Handle cancel button
 function handleResumeModalCancel() {
-    hideResumeModal();
-    // For quizzes, trigger normal start
+    // Check which page we're on
     if (typeof startPicAWord === 'function') {
-        // Do nothing - let user click START
+        // Quiz 1 (Pick-a-Word) - just hide modal, let user click START
+        hideResumeModal();
     } else if (typeof startDecodeWord === 'function') {
-        // Do nothing - let user click START
+        // Quiz 2 (Decode the Word) - just hide modal, let user click START
+        hideResumeModal();
+    } else {
+        // Story viewer - treat cancel as "Start Over"
+        if (typeof startOver === 'function') {
+            startOver();
+        } else {
+            hideResumeModal();
+        }
     }
 }
 </script>

--- a/app/pages/dashboard/finish-book.html
+++ b/app/pages/dashboard/finish-book.html
@@ -31,14 +31,14 @@
     <div class="finish-content">
         <!-- Gold Badge Display -->
         <div class="badge-container">
-            <img id="badgeImage" src="../../assets/images/badges/gold-badge.png" alt="Gold Badge">
+            <img id="badgeImage" src="../../assets/images/badges/bronze-badge.png" alt="Bronze Badge">
         </div>
 
         <!-- Completion Message -->
         <div class="progress-comment" id="completionMessage">
             <strong class="congrats">Congratulations!</strong><br>
-            
-            You've earned a <strong style="color: #FFD700;">GOLD BADGE</strong>!<br>
+
+            You've earned a <strong style="color: #cd7f32;">BRONZE BADGE</strong>!<br>
             Ready to test your vocabulary knowledge?
         </div>
 

--- a/app/pages/dashboard/story-viewer.html
+++ b/app/pages/dashboard/story-viewer.html
@@ -37,10 +37,6 @@
         <div id="speak-container"></div>
     </div>
 
-        </div>
-        <div id="speak-container"></div>
-    </div>
-
     <!-- Definition Card -->
     <div id="definition-container"></div>
 
@@ -58,8 +54,6 @@
         <button id="nextBtn" class="nav-btn">Next →</button>
     </div>
 
-    
-
     <!-- Progress Indicator -->
     <div class="progress-indicator">
         <div>
@@ -68,10 +62,11 @@
     </div>
 
     <script>
+        // Load a component into an element (returns a Promise)
         function loadComponent(elementId, filePath) {
-            fetch(filePath)
+            return fetch(filePath)
                 .then(response => {
-                    if (!response.ok) throw new Error('Network response was not ok');
+                    if (!response.ok) throw new Error('Network response was not ok: ' + filePath);
                     return response.text();
                 })
                 .then(data => {
@@ -83,13 +78,16 @@
                 .catch(err => console.error('Error loading component:', err));
         }
 
-        // Load components
+        // Load non-critical components (fire and forget — order doesn't matter)
         loadComponent('settings-container', '../components/settings-menu.html');
         loadComponent('burger-container', '../components/burger-nav.html');
         loadComponent('home-container', '../components/home-button.html');
         loadComponent('speak-container', '../components/speak-button.html');
         loadComponent('definition-container', '../components/definition-card.html');
-        loadComponent('resume-modal-container', '../components/resume-modal.html');
+
+        // ⭐ The resume modal MUST be in the DOM before initStoryViewer checks for saved progress.
+        // We store the promise so story-viewer.js can await it before calling initStoryViewer.
+        window.resumeModalReady = loadComponent('resume-modal-container', '../components/resume-modal.html');
     </script>
 
     <script src="../../js/components.js"></script>


### PR DESCRIPTION
# Fix: Resume Modal, Cross-User Progress Leakage & Quiz Progression Logic

## Summary
This PR fixes a series of bugs related to story resume functionality, quiz progress isolation per user, and quiz progression gating.

---

## Bug Fixes

### 1. Story Viewer — Resume Modal Never Appeared
**Root cause:** `loadComponent()` in `story-viewer.html` was fire-and-forget (no `await`), so `initStoryViewer()` ran before `resume-modal.html` was injected into the DOM. The `waitForModal` MutationObserver either missed the injection or timed out, causing the modal to never show and the story to always reset to segment 1.

**Fix:** `loadComponent()` now returns a Promise. The resume modal's promise is stored as `window.resumeModalReady`. `initStoryViewer()` awaits it before checking for saved progress, guaranteeing the modal is in the DOM.

**Files:** `story-viewer.html`, `story-viewer.js`

---

### 2. Story Viewer — `continueGame()` Didn't Navigate to Saved Segment
**Root cause:** `continueGame()` assumed the correct segment was already loaded behind the modal and only called `saveLastViewedSegment()` — it never called `loadSegment()`. If anything in the flow was off, the user stayed on segment 1.

**Fix:** `continueGame()` now explicitly calls `loadSegment(segmentIndex)` after the user confirms, with progress saving enabled.

**Files:** `story-viewer.js`

---

### 3. Story Viewer — `progress:getLastViewed` Returns a Plain Number, Not an Object
**Root cause:** The IPC handler for `progress:getLastViewed` returns a raw number (e.g. `4`), but `checkAndShowResumeModal` was reading `lastViewed.segmentId` — always `undefined`. So the modal condition (`segmentId > 1`) was never true.

**Fix:** Normalised the return value to handle both a plain number and an object shape:
```js
const lastViewedSegment = (typeof lastViewedRaw === 'object')
    ? lastViewedRaw.segmentId
    : lastViewedRaw;
```

**Files:** `story-viewer.js`

---

### 4. Resume Modal — Infinite Recursion on Cancel
**Root cause:** `handleResumeModalCancel()` in `resume-modal.html` checked `if (typeof handleResumeModalCancel !== 'undefined')` and then called `window.handleResumeModalCancel()` — itself — causing a stack overflow instead of calling `startOver()`.

**Fix:** Removed the self-referential call. The story viewer branch now calls `startOver()` directly.

**Files:** `resume-modal.html`

---

### 5. Quiz Progress Leaking Across User Accounts
**Root cause:** Quiz progress was saved to localStorage with keys `quiz1_progress_${storyId}` and `quiz2_progress_${storyId}` — no user ID included. Switching accounts or creating a new account would load another user's in-progress quiz and show the resume modal incorrectly.

**Fix:** Keys now include the user ID: `quiz1_progress_${getUserId()}_${storyId}`.

**Files:** `pick-a-word-quiz.js`, `decode-the-word-quiz.js`

---

### 6. Quiz Progression — Any Attempt Permanently Unlocked Next Quiz
**Root cause:** `story:getCompletionStatus` checked `quizResults.some(q => q.quiz_number === 1)` — the mere existence of any quiz result row, regardless of score, set `quiz1Completed = true`. Failing a quiz and going home still routed you to the next quiz on return.

**Fix:** Completion now requires a **perfect score** (`best_score === total_questions`). The query groups by `quiz_number` and takes `MAX(score)`, so retakes are accounted for correctly.

**Files:** `index.js`

---

### 7. Quiz Save — Always Inserted New Rows, Never Tracked Best Score
**Root cause:** `quiz:save` always did a plain `INSERT`, creating multiple rows per quiz per user. Retakes had no effect on progression gating.

**Fix:** `quiz:save` now upserts based on best score:
- First attempt → insert
- Retake with better score → update existing row
- Retake with same or worse score → skip

**Files:** `index.js`

---

### 8. Badge Logic Redesigned
**Old logic:** Gold/silver/bronze based on score ranges (3-4 = silver, 5 = gold).  
**New logic:** One badge per story, tied to milestone:
- Story completion → **Bronze**
- Quiz 1 perfect score → **Silver**
- Quiz 2 perfect score → **Gold**

**Files:** `index.js`, `pick-a-word-quiz.js`, `decode-the-word-quiz.js`

---

## Files Changed
- `story-viewer.html`
- `story-viewer.js`
- `resume-modal.html`
- `pick-a-word-quiz.js`
- `decode-the-word-quiz.js`
- `index.js`