### PR TITLE
Hotfix/scoring logic and preload.js

### DIFF
--- a/app/js/database.js
+++ b/app/js/database.js
@@ -562,63 +562,9 @@ const dbPath = path.join(dbDir, 'vocabventure.db');
     // QUIZ METHODS - REFINED
     // ============================================
     
-    // ============================================
-    // PARTIAL QUIZ PROGRESS (mid-quiz saves — never affects score/completion)
-    // ============================================
-
-    savePartialQuizProgress(userId, storyId, quizNumber, partialScore, partialQuestionIndex) {
-        // Upsert: update partial columns if a row exists, else insert a stub row with NULL score
-        const existing = this.db.prepare(`
-            SELECT id FROM quiz_results
-            WHERE user_id = ? AND story_id = ? AND quiz_number = ? AND score IS NULL
-            ORDER BY completed_at DESC LIMIT 1
-        `).get(userId, storyId, quizNumber);
-
-        if (existing) {
-            this.db.prepare(`
-                UPDATE quiz_results
-                SET partial_score = ?, partial_question_index = ?
-                WHERE id = ?
-            `).run(partialScore, partialQuestionIndex, existing.id);
-        } else {
-            // NULL score = not yet completed; getStoryCompletionStatus uses MAX(score) so NULLs are ignored
-            this.db.prepare(`
-                INSERT INTO quiz_results (user_id, story_id, quiz_number, score, total_questions, badge_type, partial_score, partial_question_index)
-                VALUES (?, ?, ?, NULL, NULL, NULL, ?, ?)
-            `).run(userId, storyId, quizNumber, partialScore, partialQuestionIndex);
-        }
-    }
-
-    getPartialQuizProgress(userId, storyId, quizNumber) {
-        const row = this.db.prepare(`
-            SELECT partial_score, partial_question_index, score
-            FROM quiz_results
-            WHERE user_id = ? AND story_id = ? AND quiz_number = ? AND score IS NULL
-            ORDER BY completed_at DESC LIMIT 1
-        `).get(userId, storyId, quizNumber);
-
-        if (!row || row.partial_question_index === null) return null;
-
-        return {
-            partialScore: row.partial_score,
-            partialQuestionIndex: row.partial_question_index
-        };
-    }
-
-    clearPartialQuizProgress(userId, storyId, quizNumber) {
-        // Delete stub rows (score IS NULL) so resume modal never shows after finishing
-        this.db.prepare(`
-            DELETE FROM quiz_results
-            WHERE user_id = ? AND story_id = ? AND quiz_number = ? AND score IS NULL
-        `).run(userId, storyId, quizNumber);
-    }
-
     saveQuizResult(userId, storyId, quizNumber, score, totalQuestions) {
         // Calculate badge type based on score
         const badgeType = this.calculateQuizBadge(score, totalQuestions);
-
-        // Remove any partial stub rows first so resume modal never appears after completion
-        this.clearPartialQuizProgress(userId, storyId, quizNumber);
         
         const stmt = this.db.prepare(`
             INSERT INTO quiz_results (user_id, story_id, quiz_number, score, total_questions, badge_type)
@@ -659,7 +605,7 @@ const dbPath = path.join(dbDir, 'vocabventure.db');
         const stmt = this.db.prepare(`
             SELECT MAX(score) as best_score, total_questions, badge_type
             FROM quiz_results 
-            WHERE user_id = ? AND story_id = ? AND quiz_number = ?
+            WHERE user_id = ? AND story_id = ? AND quiz_number = ? AND score IS NOT NULL
         `);
         return stmt.get(userId, storyId, quizNumber);
     }
@@ -794,7 +740,7 @@ getBadgeStats(userId) {
         const quizResults = this.db.prepare(`
             SELECT quiz_number, MAX(score) as best_score, total_questions
             FROM quiz_results
-            WHERE user_id = ? AND story_id = ?
+            WHERE user_id = ? AND story_id = ? AND score IS NOT NULL
             GROUP BY quiz_number
         `).all(userId, storyId);
 

--- a/app/js/decode-the-word-quiz.js
+++ b/app/js/decode-the-word-quiz.js
@@ -6,383 +6,231 @@ let currentQuestionIndex = 0;
 let score = 0;
 let userAnswers = [];
 
-// Get story ID
 function getStoryId() {
-    const urlParams = new URLSearchParams(window.location.search);
-    const urlStoryId = urlParams.get('story');
-    const sessionStoryId = sessionStorage.getItem('quizStoryId');
-    
-    return parseInt(urlStoryId || sessionStoryId) || 1;
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlStoryId = urlParams.get('story');
+  const sessionStoryId = sessionStorage.getItem('quizStoryId');
+  return parseInt(urlStoryId || sessionStoryId) || 1;
 }
 
-// Get current user ID (falls back to lastUserId)
 function getUserId() {
   const currentUser = JSON.parse(localStorage.getItem('currentUser'));
   return currentUser?.id || parseInt(localStorage.getItem('lastUserId')) || 'guest';
 }
 
-// Check for saved quiz progress (from DB)
-async function getSavedQuizProgress() {
+// Check for saved quiz progress (localStorage only — never touches DB)
+function getSavedQuizProgress() {
   const storyId = getStoryId();
-  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
-  if (!currentUser) return null;
-  try {
-    const { ipcRenderer } = require('electron');
-    const partial = await ipcRenderer.invoke('quiz:getPartial', {
-      userId: currentUser.id,
-      storyId: storyId,
-      quizNumber: 2
-    });
-    return partial; // { partialScore, partialQuestionIndex } or null
-  } catch (e) {
-    console.error('Error getting partial quiz progress:', e);
-    return null;
+  const savedProgress = localStorage.getItem(`quiz2_progress_${getUserId()}_${storyId}`);
+  if (savedProgress) {
+    try { return JSON.parse(savedProgress); } catch (e) { return null; }
   }
+  return null;
 }
 
-// Save quiz progress to DB (partial only — does NOT affect score/completion status)
-async function saveQuizProgress(questionIndex, score, answers) {
+// Save partial progress to localStorage only (never touches DB score columns)
+function saveQuizProgress(nextQuestionIndex, currentScore) {
   const storyId = getStoryId();
-  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
-  if (!currentUser) return;
-  try {
-    const { ipcRenderer } = require('electron');
-    await ipcRenderer.invoke('quiz:savePartial', {
-      userId: currentUser.id,
-      storyId: storyId,
-      quizNumber: 2,
-      partialScore: score,
-      partialQuestionIndex: questionIndex
-    });
-    console.log(`📊 Quiz 2 partial progress saved to DB - Question ${questionIndex + 1}, Score: ${score}`);
-  } catch (e) {
-    console.error('Error saving partial quiz progress:', e);
-  }
+  localStorage.setItem(`quiz2_progress_${getUserId()}_${storyId}`, JSON.stringify({
+    partialQuestionIndex: nextQuestionIndex,
+    partialScore: currentScore,
+    timestamp: Date.now()
+  }));
+  console.log(`📊 Quiz 2 partial progress saved - Next question: ${nextQuestionIndex + 1}, Score: ${currentScore}`);
 }
 
-// Show resume modal for quiz
 function showQuizResumeModal(savedProgress) {
   const modal = document.getElementById('resumeModalOverlay');
   if (modal) {
     modal.classList.remove('hidden');
-    console.log('📻 Quiz resume modal shown - saved at question:', savedProgress.questionIndex + 1);
+    console.log('📻 Quiz resume modal shown - saved at question:', savedProgress.partialQuestionIndex + 1);
   }
 }
 
-// Hide resume modal
 function hideResumeModal() {
   const modal = document.getElementById('resumeModalOverlay');
-  if (modal) {
-    modal.classList.add('hidden');
-  }
+  if (modal) modal.classList.add('hidden');
 }
 
-// Resume quiz from saved progress
-async function continueGame() {
+function continueGame() {
   console.log('▶️ Resuming quiz from saved progress');
   hideResumeModal();
-  
-  const savedProgress = await getSavedQuizProgress();
+  const savedProgress = getSavedQuizProgress();
   if (savedProgress && quizData) {
     currentQuestionIndex = savedProgress.partialQuestionIndex;
     score = savedProgress.partialScore;
     userAnswers = [];
-    
-    // Show quiz screen
     document.getElementById('quizIntro').style.display = 'none';
     document.getElementById('quizQuestion').style.display = 'block';
-    
-    // Load the next unanswered question
     loadQuestion(currentQuestionIndex);
-    console.log(`📍 Resumed at question ${currentQuestionIndex + 1}, current score: ${score}`);
+    console.log(`📍 Resumed at question ${currentQuestionIndex + 1}, score: ${score}`);
   }
 }
 
-// Start quiz again from beginning
-async function startAgain() {
+function startAgain() {
   console.log('🔄 Starting quiz over');
   hideResumeModal();
-
-  // Clear partial progress from DB
-  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
-  if (currentUser) {
-    try {
-      const { ipcRenderer } = require('electron');
-      await ipcRenderer.invoke('quiz:clearPartial', {
-        userId: currentUser.id,
-        storyId: getStoryId(),
-        quizNumber: 2
-      });
-    } catch (e) {
-      console.error('Error clearing partial progress:', e);
-    }
-  }
-
-  // Reset state
+  localStorage.removeItem(`quiz2_progress_${getUserId()}_${getStoryId()}`);
   currentQuestionIndex = 0;
   score = 0;
   userAnswers = [];
-
-  // Go back to the START screen (intro) so the user sees the starting context/instructions again
   document.getElementById('quizQuestion').style.display = 'none';
   document.getElementById('quizIntro').style.display = 'block';
 }
 
-// For backward compatibility with story-viewer's continueGame
-function startOver() {
-  startAgain();
-}
+function startOver() { startAgain(); }
 
-// Load story data and quiz
 async function loadQuizData() {
-    const storyId = getStoryId();
-    
-    try {
-        const response = await fetch(`../../data/stories/story-${storyId}.json`);
-        if (!response.ok) {
-            throw new Error('Story not found');
-        }
-        storyData = await response.json();
-        quizData = storyData.quiz2; // Decode the Word is quiz2
-        
-        console.log('Quiz loaded:', quizData.title);
-        console.log('Questions:', quizData.questions.length);
-        
-        document.getElementById('totalQuestions').textContent = quizData.questions.length;
-
-        // Check for saved partial progress in DB
-        const savedProgress = await getSavedQuizProgress();
-        if (savedProgress && savedProgress.partialQuestionIndex < quizData.questions.length) {
-          console.log('🔄 Found saved quiz progress - showing resume modal');
-          showQuizResumeModal(savedProgress);
-        }
-        
-    } catch (error) {
-        console.error('Error loading quiz:', error);
-        alert('Failed to load quiz. Redirecting to library...');
-        window.location.href = 'library.html';
+  const storyId = getStoryId();
+  try {
+    const response = await fetch(`../../data/stories/story-${storyId}.json`);
+    if (!response.ok) throw new Error('Story not found');
+    storyData = await response.json();
+    quizData = storyData.quiz2;
+    console.log('Quiz loaded:', quizData.title);
+    console.log('Questions:', quizData.questions.length);
+    document.getElementById('totalQuestions').textContent = quizData.questions.length;
+    const savedProgress = getSavedQuizProgress();
+    if (savedProgress && savedProgress.partialQuestionIndex < quizData.questions.length) {
+      console.log('🔄 Found saved quiz progress - showing resume modal');
+      showQuizResumeModal(savedProgress);
     }
+  } catch (error) {
+    console.error('Error loading quiz:', error);
+    alert('Failed to load quiz. Redirecting to library...');
+    window.location.href = 'library.html';
+  }
 }
 
-// Start the quiz
 function startDecodeWord() {
-    // Hide intro, show quiz
-    document.getElementById('quizIntro').style.display = 'none';
-    document.getElementById('quizQuestion').style.display = 'block';
-    
-    // Load first question
-    loadQuestion(0);
+  document.getElementById('quizIntro').style.display = 'none';
+  document.getElementById('quizQuestion').style.display = 'block';
+  loadQuestion(0);
 }
 
-// Load a specific question
 function loadQuestion(index) {
-    if (!quizData || index >= quizData.questions.length) {
-        return;
-    }
-    
-    currentQuestionIndex = index;
-    const question = quizData.questions[index];
-    
-    // Update question counter
-    document.getElementById('currentQuestion').textContent = index + 1;
-    
-    // Format the sentence with underlined word
-    const sentenceWithUnderline = formatSentenceWithUnderline(
-        question.question, 
-        question.underlinedWord
-    );
-    
-    // Display sentence and question prompt
-    document.getElementById('sentenceText').innerHTML = sentenceWithUnderline;
-    document.getElementById('questionPrompt').textContent = question.questionPrompt;
-    
-    // Create answer buttons
-    const buttonsContainer = document.getElementById('answerButtons');
-    buttonsContainer.innerHTML = '';
-    
-    question.options.forEach((option, idx) => {
-        const button = document.createElement('button');
-        
-        // CHANGED CLASS TO answer-btn (The long style)
-        button.className = 'answer-btn'; 
-
-        const choices = idx;
-        button.textContent = `${String(option).toLowerCase()}`;
-        
-        button.onclick = () => checkAnswer(idx);
-        buttonsContainer.appendChild(button);
-    });
-    
-    // Hide feedback message
-    document.getElementById('feedbackMessage').style.display = 'none';
+  if (!quizData || index >= quizData.questions.length) return;
+  currentQuestionIndex = index;
+  const question = quizData.questions[index];
+  document.getElementById('currentQuestion').textContent = index + 1;
+  const sentenceWithUnderline = formatSentenceWithUnderline(question.question, question.underlinedWord);
+  document.getElementById('sentenceText').innerHTML = sentenceWithUnderline;
+  document.getElementById('questionPrompt').textContent = question.questionPrompt;
+  const buttonsContainer = document.getElementById('answerButtons');
+  buttonsContainer.innerHTML = '';
+  question.options.forEach((option, idx) => {
+    const button = document.createElement('button');
+    button.className = 'answer-btn';
+    button.textContent = String(option).toLowerCase();
+    button.onclick = () => checkAnswer(idx);
+    buttonsContainer.appendChild(button);
+  });
+  document.getElementById('feedbackMessage').style.display = 'none';
 }
 
-// Format sentence with underlined word
 function formatSentenceWithUnderline(sentence, wordToUnderline) {
-    // Case-insensitive search and replace with underlined version
-    const regex = new RegExp(`\\b${wordToUnderline}\\b`, 'gi');
-    
-    return sentence.replace(regex, (match) => {
-        return `<span style="text-decoration: underline; text-decoration-thickness: 2px; text-decoration-color: #ffffff; font-weight: 700;">${match}</span>`;
-    });
+  const regex = new RegExp(`\\b${wordToUnderline}\\b`, 'gi');
+  return sentence.replace(regex, (match) =>
+    `<span style="text-decoration:underline;text-decoration-thickness:2px;text-decoration-color:#ffffff;font-weight:700;">${match}</span>`
+  );
 }
 
-// Check if answer is correct
 function checkAnswer(selectedIndex) {
-    const question = quizData.questions[currentQuestionIndex];
-    const isCorrect = selectedIndex === question.correctAnswer;
-    
-    // Update score
-    if (isCorrect) {
-        score++;
-    }
-    
-    // Store answer
-    userAnswers.push({
-        questionIndex: currentQuestionIndex,
-        selectedIndex: selectedIndex,
-        correct: isCorrect
-    });
+  const question = quizData.questions[currentQuestionIndex];
+  const isCorrect = selectedIndex === question.correctAnswer;
+  if (isCorrect) score++;
+  userAnswers.push({ questionIndex: currentQuestionIndex, selectedIndex, correct: isCorrect });
 
-    // Save progress to localStorage
-    saveQuizProgress(currentQuestionIndex, score, userAnswers);
-    
-    console.log('Stored answer:', {questionIndex: currentQuestionIndex, selectedIndex, correct: isCorrect, correctAnswer: question.correctAnswer});
+  // Save NEXT question index so resume lands on the correct unanswered question
+  saveQuizProgress(currentQuestionIndex + 1, score);
 
-    // Show feedback
-    showFeedback(isCorrect, question.explanation);
-    
-    // Disable all buttons and show visual feedback
-        const buttons = document.querySelectorAll('#answerButtons .answer-btn');    buttons.forEach((btn, idx) => {
-        btn.disabled = true;
-        btn.style.cursor = 'not-allowed';
-        
-        if (idx === question.correctAnswer) {
-            // Correct answer - green
-            btn.style.background = '#4ade80';
-            btn.style.border = '3px solid #22c55e';
-            btn.style.color = 'white';
-            btn.style.transform = 'scale(1.05)';
-        } else if (idx === selectedIndex && !isCorrect) {
-            // Wrong selection - red
-            btn.style.background = '#ef4444';
-            btn.style.border = '3px solid #dc2626';
-            btn.style.color = 'white';
-        } else {
-            // Other options - fade out
-            btn.style.opacity = '0.4';
-        }
-    });
-    
-    // Continue after delay
-    setTimeout(() => {
-        if (currentQuestionIndex < quizData.questions.length - 1) {
-            loadQuestion(currentQuestionIndex + 1);
-        } else {
-            finishQuiz();
-        }
-    }, 3000); // 3 seconds to read feedback
-}
+  console.log('Stored answer:', { questionIndex: currentQuestionIndex, selectedIndex, correct: isCorrect, correctAnswer: question.correctAnswer });
+  showFeedback(isCorrect, question.explanation);
 
-// Show feedback message
-function showFeedback(isCorrect, explanation) {
-    const feedbackElement = document.getElementById('feedbackMessage');
-    
-    if (isCorrect) {
-        feedbackElement.innerHTML = `
-            <div style="color: #ffffff;">
-                <div style="font-size: 2rem; margin-bottom: 10px;">✓</div>
-                <div style="font-size: 2.3rem;">Correct!</div>
-                <div style="font-size: 1.8rem; margin-top: 10px; font-weight: normal; opacity: 0.9;">
-                    ${explanation}
-                </div>
-            </div>
-        `;
-        feedbackElement.style.background = 'rgba(74, 222, 128, 0.2)';
-        feedbackElement.style.border = '2px solid #4ade80';
+  const buttons = document.querySelectorAll('#answerButtons .answer-btn');
+  buttons.forEach((btn, idx) => {
+    btn.disabled = true;
+    btn.style.cursor = 'not-allowed';
+    if (idx === question.correctAnswer) {
+      btn.style.background = '#4ade80';
+      btn.style.border = '3px solid #22c55e';
+      btn.style.color = 'white';
+      btn.style.transform = 'scale(1.05)';
+    } else if (idx === selectedIndex && !isCorrect) {
+      btn.style.background = '#ef4444';
+      btn.style.border = '3px solid #dc2626';
+      btn.style.color = 'white';
     } else {
-        feedbackElement.innerHTML = `
-            <div style="color: #ffffff;">
-                <div style="font-size: 2rem; margin-bottom: 10px;">✗</div>
-                <div style="font-size: 2.3rem;">Not quite!</div>
-                <div style="font-size: 1.8rem; margin-top: 10px; font-weight: normal; opacity: 0.9;">
-                    ${explanation}
-                </div>
-            </div>
-        `;
-        feedbackElement.style.background = 'rgba(239, 68, 68, 0.2)';
-        feedbackElement.style.border = '2px solid #ef4444';
+      btn.style.opacity = '0.4';
     }
-    
-    feedbackElement.style.display = 'block';
+  });
+
+  setTimeout(() => {
+    if (currentQuestionIndex < quizData.questions.length - 1) {
+      loadQuestion(currentQuestionIndex + 1);
+    } else {
+      finishQuiz();
+    }
+  }, 3000);
 }
 
-// Calculate badge type based on score
-// Quiz 2: perfect score = gold, anything less = bronze
+function showFeedback(isCorrect, explanation) {
+  const feedbackElement = document.getElementById('feedbackMessage');
+  if (isCorrect) {
+    feedbackElement.innerHTML = `<div style="color:#ffffff;"><div style="font-size:2rem;margin-bottom:10px;">✓</div><div style="font-size:2.3rem;">Correct!</div><div style="font-size:1.8rem;margin-top:10px;font-weight:normal;opacity:0.9;">${explanation}</div></div>`;
+    feedbackElement.style.background = 'rgba(74, 222, 128, 0.2)';
+    feedbackElement.style.border = '2px solid #4ade80';
+  } else {
+    feedbackElement.innerHTML = `<div style="color:#ffffff;"><div style="font-size:2rem;margin-bottom:10px;">✗</div><div style="font-size:2.3rem;">Not quite!</div><div style="font-size:1.8rem;margin-top:10px;font-weight:normal;opacity:0.9;">${explanation}</div></div>`;
+    feedbackElement.style.background = 'rgba(239, 68, 68, 0.2)';
+    feedbackElement.style.border = '2px solid #ef4444';
+  }
+  feedbackElement.style.display = 'block';
+}
+
 function calculateBadgeType(score, total) {
-    return score === total ? 'gold' : 'bronze';
+  return score === total ? 'gold' : 'bronze';
 }
 
-// Finish quiz
 async function finishQuiz() {
-    const badgeType = calculateBadgeType(score, quizData.questions.length);
-    const storyId = getStoryId();
-    
-    // Clear partial progress from DB since quiz is complete (saveQuizResults also clears via DB method)
-    const currentUser = JSON.parse(localStorage.getItem('currentUser'));
-    if (currentUser) {
-        try {
-            const { ipcRenderer } = require('electron');
-            await ipcRenderer.invoke('quiz:clearPartial', {
-                userId: currentUser.id,
-                storyId: storyId,
-                quizNumber: 2
-            });
-        } catch (e) {
-            console.error('Error clearing partial progress on finish:', e);
-        }
-    }
-    
-    // Store quiz results with badge type
-    sessionStorage.setItem('quiz2Results', JSON.stringify({
-        score: score,
-        total: quizData.questions.length,
-        percentage: Math.round((score / quizData.questions.length) * 100),
-        badgeType: badgeType,
-        answers: userAnswers
-    }));
-    
-    // Save quiz results to database
-    saveQuizResults(badgeType);
-    
-    // Go to result page (quiz 2 complete)
-    window.location.href = `game-result.html?story=${storyId}&quiz=2`;
+  const badgeType = calculateBadgeType(score, quizData.questions.length);
+  const storyId = getStoryId();
+
+  // Clear partial progress from localStorage
+  localStorage.removeItem(`quiz2_progress_${getUserId()}_${storyId}`);
+
+  sessionStorage.setItem('quiz2Results', JSON.stringify({
+    score,
+    total: quizData.questions.length,
+    percentage: Math.round((score / quizData.questions.length) * 100),
+    badgeType,
+    answers: userAnswers
+  }));
+
+  // Await DB save before navigating so the score is committed
+  await saveQuizResults(badgeType);
+  window.location.href = `game-result.html?story=${storyId}&quiz=2`;
 }
 
-// Save quiz results to database
 async function saveQuizResults(badgeType) {
-    try {
-        const { ipcRenderer } = require('electron');
-        const currentUser = JSON.parse(localStorage.getItem('currentUser'));
-        const storyId = getStoryId();
-        
-        if (currentUser) {
-            // Save quiz result score only — badge:upgrade in game-result.js handles the badge
-            await ipcRenderer.invoke('quiz:save', {
-                userId: currentUser.id,
-                storyId: storyId,
-                quizNumber: 2,
-                score: score,
-                totalQuestions: quizData.questions.length,
-                badgeType: badgeType
-            });
-            
-            console.log(`Quiz 2 results saved (${badgeType})`);
-        }
-    } catch (error) {
-        console.error('Error saving quiz results:', error);
+  try {
+    const { ipcRenderer } = require('electron');
+    const currentUser = JSON.parse(localStorage.getItem('currentUser'));
+    const storyId = getStoryId();
+    if (currentUser) {
+      await ipcRenderer.invoke('quiz:save', {
+        userId: currentUser.id,
+        storyId,
+        quizNumber: 2,
+        score,
+        totalQuestions: quizData.questions.length,
+        badgeType
+      });
+      console.log(`Quiz 2 results saved (${badgeType})`);
     }
+  } catch (error) {
+    console.error('Error saving quiz results:', error);
+  }
 }
 
-// Initialize when page loads
 window.addEventListener('DOMContentLoaded', loadQuizData);

--- a/app/js/library.js
+++ b/app/js/library.js
@@ -178,7 +178,6 @@ function getTotalSegments(storyId) {
     // Render single book
     function renderBook(story) {
         const locked = !story.isActive;
-        const initialWidth = locked ? '0%' : '0%';
         
         return `
             <div class="book-item ${locked ? "locked" : ""}"
@@ -188,11 +187,15 @@ function getTotalSegments(storyId) {
                  data-story-id="${story.id}">
              
                 <div class="book-cover-wrapper">
-                    <img src="../../${story.coverImage}" alt="${story.title}">
+                    <img 
+                        src="../../${story.coverImage}" 
+                        alt="${story.title}"
+                        onload="this.closest('.book-item').querySelector('.progress-container').style.opacity='1'"
+                    >
                     ${locked ? `<div class="coming-soon">Coming Soon</div>` : ""}
                 </div>
-                <div class="progress-container">
-                    <div class="progress-fill" style="width: ${initialWidth};" data-progress="${story.id}"></div>
+                <div class="progress-container" style="opacity: 0; transition: opacity 0.3s ease;">
+                    <div class="progress-fill" style="width: 0%;" data-progress="${story.id}"></div>
                 </div>
             </div>
         `;
@@ -359,6 +362,3 @@ function attachBookClicks() {
     });
 }
 
-// ============================================
-// SEARCH AND FILTER
-// ============================================

--- a/app/js/pick-a-word-quiz.js
+++ b/app/js/pick-a-word-quiz.js
@@ -11,148 +11,91 @@ function getStoryId() {
   const urlParams = new URLSearchParams(window.location.search);
   const urlStoryId = urlParams.get("story");
   const sessionStoryId = sessionStorage.getItem("quizStoryId");
-
   return parseInt(urlStoryId || sessionStoryId) || 1;
 }
 
-// Get current user ID (falls back to lastUserId)
 function getUserId() {
   const currentUser = JSON.parse(localStorage.getItem('currentUser'));
   return currentUser?.id || parseInt(localStorage.getItem('lastUserId')) || 'guest';
 }
 
-// Check for saved quiz progress (from DB)
-async function getSavedQuizProgress() {
+// Check for saved quiz progress (localStorage only — never touches DB)
+function getSavedQuizProgress() {
   const storyId = getStoryId();
-  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
-  if (!currentUser) return null;
-  try {
-    const { ipcRenderer } = require('electron');
-    const partial = await ipcRenderer.invoke('quiz:getPartial', {
-      userId: currentUser.id,
-      storyId: storyId,
-      quizNumber: 1
-    });
-    return partial; // { partialScore, partialQuestionIndex } or null
-  } catch (e) {
-    console.error('Error getting partial quiz progress:', e);
-    return null;
+  const savedProgress = localStorage.getItem(`quiz1_progress_${getUserId()}_${storyId}`);
+  if (savedProgress) {
+    try {
+      return JSON.parse(savedProgress);
+    } catch (e) {
+      return null;
+    }
   }
+  return null;
 }
 
-// Save quiz progress to DB (partial only — does NOT affect score/completion status)
-async function saveQuizProgress(questionIndex, score, answers) {
+// Save partial progress to localStorage only (never touches DB score columns)
+function saveQuizProgress(nextQuestionIndex, currentScore) {
   const storyId = getStoryId();
-  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
-  if (!currentUser) return;
-  try {
-    const { ipcRenderer } = require('electron');
-    await ipcRenderer.invoke('quiz:savePartial', {
-      userId: currentUser.id,
-      storyId: storyId,
-      quizNumber: 1,
-      partialScore: score,
-      partialQuestionIndex: questionIndex
-    });
-    console.log(`📊 Quiz 1 partial progress saved to DB - Question ${questionIndex + 1}, Score: ${score}`);
-  } catch (e) {
-    console.error('Error saving partial quiz progress:', e);
-  }
+  localStorage.setItem(`quiz1_progress_${getUserId()}_${storyId}`, JSON.stringify({
+    partialQuestionIndex: nextQuestionIndex,
+    partialScore: currentScore,
+    timestamp: Date.now()
+  }));
+  console.log(`📊 Quiz 1 partial progress saved - Next question: ${nextQuestionIndex + 1}, Score: ${currentScore}`);
 }
 
-// Show resume modal for quiz
 function showQuizResumeModal(savedProgress) {
   const modal = document.getElementById('resumeModalOverlay');
   if (modal) {
     modal.classList.remove('hidden');
-    console.log('📻 Quiz resume modal shown - saved at question:', savedProgress.questionIndex + 1);
+    console.log('📻 Quiz resume modal shown - saved at question:', savedProgress.partialQuestionIndex + 1);
   }
 }
 
-// Hide resume modal
 function hideResumeModal() {
   const modal = document.getElementById('resumeModalOverlay');
-  if (modal) {
-    modal.classList.add('hidden');
-  }
+  if (modal) modal.classList.add('hidden');
 }
 
-// Resume quiz from saved progress
-async function continueGame() {
+function continueGame() {
   console.log('▶️ Resuming quiz from saved progress');
   hideResumeModal();
-  
-  const savedProgress = await getSavedQuizProgress();
+  const savedProgress = getSavedQuizProgress();
   if (savedProgress && quizData) {
     currentQuestionIndex = savedProgress.partialQuestionIndex;
     score = savedProgress.partialScore;
     userAnswers = [];
-    
-    // Show quiz screen
     document.getElementById('quizIntro').style.display = 'none';
     document.getElementById('quizQuestion').style.display = 'block';
-    
-    // Load the next unanswered question
     loadQuestion(currentQuestionIndex);
-    console.log(`📍 Resumed at question ${currentQuestionIndex + 1}, current score: ${score}`);
+    console.log(`📍 Resumed at question ${currentQuestionIndex + 1}, score: ${score}`);
   }
 }
 
-// Start quiz again from beginning
-async function startAgain() {
+function startAgain() {
   console.log('🔄 Starting quiz over');
   hideResumeModal();
-
-  // Clear partial progress from DB
-  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
-  if (currentUser) {
-    try {
-      const { ipcRenderer } = require('electron');
-      await ipcRenderer.invoke('quiz:clearPartial', {
-        userId: currentUser.id,
-        storyId: getStoryId(),
-        quizNumber: 1
-      });
-    } catch (e) {
-      console.error('Error clearing partial progress:', e);
-    }
-  }
-
-  // Reset state
+  localStorage.removeItem(`quiz1_progress_${getUserId()}_${getStoryId()}`);
   currentQuestionIndex = 0;
   score = 0;
   userAnswers = [];
-
-  // Go back to the START screen (intro) so the user sees the starting picture/prompt again
   document.getElementById('quizQuestion').style.display = 'none';
   document.getElementById('quizIntro').style.display = 'block';
 }
 
-// For backward compatibility with story-viewer's continueGame
-function startOver() {
-  startAgain();
-}
+function startOver() { startAgain(); }
 
-// Load story data and quiz
 async function loadQuizData() {
   const storyId = getStoryId();
-
   try {
     const response = await fetch(`../../data/stories/story-${storyId}.json`);
-    if (!response.ok) {
-      throw new Error("Story not found");
-    }
+    if (!response.ok) throw new Error("Story not found");
     storyData = await response.json();
-    quizData = storyData.quiz1; // Pic-a-Word is quiz1
-
+    quizData = storyData.quiz1;
     console.log("Quiz loaded:", quizData.title);
     console.log("Questions:", quizData.questions.length);
-
-    document.getElementById("totalQuestions").textContent =
-      quizData.questions.length;
-
-    // Check for saved partial progress in DB
-    const savedProgress = await getSavedQuizProgress();
+    document.getElementById("totalQuestions").textContent = quizData.questions.length;
+    const savedProgress = getSavedQuizProgress();
     if (savedProgress && savedProgress.partialQuestionIndex < quizData.questions.length) {
       console.log('🔄 Found saved quiz progress - showing resume modal');
       showQuizResumeModal(savedProgress);
@@ -164,219 +107,126 @@ async function loadQuizData() {
   }
 }
 
-// Start the quiz
 function startPicAWord() {
-  // Hide intro, show quiz
   document.getElementById("quizIntro").style.display = "none";
   document.getElementById("quizQuestion").style.display = "block";
-
-  // Load first question
   loadQuestion(0);
 }
 
-// Load a specific question
-// Load a specific question
 function loadQuestion(index) {
-    if (!quizData || index >= quizData.questions.length) {
-        return;
-    }
-
-    currentQuestionIndex = index;
-    const question = quizData.questions[index];
-
-    // Update question counter
-    document.getElementById("currentQuestion").textContent = index + 1;
-
-    // 1. GET IMAGE PATH
-    const correctWord = question.options[question.correctAnswer];
-    const storyId = getStoryId();
-    // Build image path based on correct answer
-    const imagePath = `../../assets/images/pick-a-word/story${storyId}-pick-a-word/${correctWord.toLowerCase().replace(/\s+/g, "")}.png`;
-
-    // 2. SET THE IMAGE (Top Container)
-    const imgElement = document.getElementById("mainQuizImage");
-    imgElement.src = imagePath;
-    
-    // Add error handling for the image
-    imgElement.onerror = function() {
-        this.src = '../../assets/images/icons/question-mark-icon.svg'; 
-        console.error('Image not found:', imagePath);
-    };
-
-    // 3. SET THE TEXT (Below Container)
-    // We do NOT split the string anymore. We just show the question with the blanks.
-    document.getElementById("questionText").innerHTML = question.question;
-
-    // 4. CREATE BUTTONS
-    const buttonsContainer = document.getElementById("answerButtons");
-    buttonsContainer.innerHTML = "";
-
-    question.options.forEach((option, idx) => {
-        const button = document.createElement("button");
-        button.className = "start-button";
-     
-        button.textContent = `${String(option).toLowerCase()}`;
-
-        button.onclick = () => checkAnswer(idx);
-        buttonsContainer.appendChild(button);
-    });
-
-    // Hide feedback message
-    document.getElementById("feedbackMessage").style.display = "none";
+  if (!quizData || index >= quizData.questions.length) return;
+  currentQuestionIndex = index;
+  const question = quizData.questions[index];
+  document.getElementById("currentQuestion").textContent = index + 1;
+  const correctWord = question.options[question.correctAnswer];
+  const storyId = getStoryId();
+  const imagePath = `../../assets/images/pick-a-word/story${storyId}-pick-a-word/${correctWord.toLowerCase().replace(/\s+/g, "")}.png`;
+  const imgElement = document.getElementById("mainQuizImage");
+  imgElement.src = imagePath;
+  imgElement.onerror = function() {
+    this.src = '../../assets/images/icons/question-mark-icon.svg';
+  };
+  document.getElementById("questionText").innerHTML = question.question;
+  const buttonsContainer = document.getElementById("answerButtons");
+  buttonsContainer.innerHTML = "";
+  question.options.forEach((option, idx) => {
+    const button = document.createElement("button");
+    button.className = "start-button";
+    button.textContent = String(option).toLowerCase();
+    button.onclick = () => checkAnswer(idx);
+    buttonsContainer.appendChild(button);
+  });
+  document.getElementById("feedbackMessage").style.display = "none";
 }
 
-// Check if answer is correct
 function checkAnswer(selectedIndex) {
   const question = quizData.questions[currentQuestionIndex];
   const isCorrect = selectedIndex === question.correctAnswer;
+  if (isCorrect) score++;
+  userAnswers.push({ questionIndex: currentQuestionIndex, selectedIndex, correct: isCorrect });
 
-  // Update score
-  if (isCorrect) {
-    score++;
-  }
+  // Save NEXT question index so resume lands on the correct unanswered question
+  saveQuizProgress(currentQuestionIndex + 1, score);
 
-  // Store answer
-  userAnswers.push({
-    questionIndex: currentQuestionIndex,
-    selectedIndex: selectedIndex,
-    correct: isCorrect,
-  });
-
-  // Save progress to localStorage
-  saveQuizProgress(currentQuestionIndex, score, userAnswers);
-
-  // Show feedback
   showFeedback(isCorrect, question.explanation);
-
-  // Disable all buttons and show visual feedback
   const buttons = document.querySelectorAll("#answerButtons .start-button");
   buttons.forEach((btn, idx) => {
     btn.disabled = true;
     btn.style.cursor = "not-allowed";
-
     if (idx === question.correctAnswer) {
-      // Correct answer - green
       btn.style.background = "#4ade80";
       btn.style.border = "3px solid #22c55e";
       btn.style.color = "white";
       btn.style.transform = "scale(1.05)";
     } else if (idx === selectedIndex && !isCorrect) {
-      // Wrong selection - red
       btn.style.background = "#ef4444";
       btn.style.border = "3px solid #dc2626";
       btn.style.color = "white";
     } else {
-      // Other options - fade out
       btn.style.opacity = "0.4";
     }
   });
-
-  // Continue after delay
   setTimeout(() => {
     if (currentQuestionIndex < quizData.questions.length - 1) {
       loadQuestion(currentQuestionIndex + 1);
     } else {
       finishQuiz();
     }
-  }, 3000); // 3 seconds to read feedback
+  }, 3000);
 }
 
-// Show feedback message
 function showFeedback(isCorrect, explanation) {
   const feedbackElement = document.getElementById("feedbackMessage");
-
   if (isCorrect) {
-    feedbackElement.innerHTML = `
-            <div style="color: #ffffff;">
-                <div style="font-size: 2rem; margin-bottom: 10px;">✓</div>
-                <div style="font-size: 2.3rem;">Correct!</div>
-                <div style="font-size: 1.8rem; margin-top: 10px; font-weight: normal; opacity: 0.9;">
-                    ${explanation}
-                </div>
-            </div>
-        `;
+    feedbackElement.innerHTML = `<div style="color:#ffffff;"><div style="font-size:2rem;margin-bottom:10px;">✓</div><div style="font-size:2.3rem;">Correct!</div><div style="font-size:1.8rem;margin-top:10px;font-weight:normal;opacity:0.9;">${explanation}</div></div>`;
     feedbackElement.style.background = "rgba(74, 222, 128, 0.2)";
     feedbackElement.style.border = "2px solid #4ade80";
   } else {
-    feedbackElement.innerHTML = `
-            <div style="color: #ffffff;">
-                <div style="font-size: 2rem; margin-bottom: 10px;">✗</div>
-                <div style="font-size: 2.3rem;">Not quite!</div>
-                <div style="font-size: 1.8rem; margin-top: 10px; font-weight: normal; opacity: 0.9;">
-                    ${explanation}
-                </div>
-            </div>
-        `;
+    feedbackElement.innerHTML = `<div style="color:#ffffff;"><div style="font-size:2rem;margin-bottom:10px;">✗</div><div style="font-size:2.3rem;">Not quite!</div><div style="font-size:1.8rem;margin-top:10px;font-weight:normal;opacity:0.9;">${explanation}</div></div>`;
     feedbackElement.style.background = "rgba(239, 68, 68, 0.2)";
     feedbackElement.style.border = "2px solid #ef4444";
   }
-
   feedbackElement.style.display = "block";
 }
 
-// Calculate badge type based on score
-// Quiz 1: perfect score = silver, anything less = bronze
 function calculateBadgeType(score, total) {
   return score === total ? 'silver' : 'bronze';
 }
 
-// Finish quiz
 async function finishQuiz() {
   const badgeType = calculateBadgeType(score, quizData.questions.length);
   const storyId = getStoryId();
 
-  // Clear partial progress from DB since quiz is complete
-  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
-  if (currentUser) {
-    try {
-      const { ipcRenderer } = require('electron');
-      await ipcRenderer.invoke('quiz:clearPartial', {
-        userId: currentUser.id,
-        storyId: storyId,
-        quizNumber: 1
-      });
-    } catch (e) {
-      console.error('Error clearing partial progress on finish:', e);
-    }
-  }
+  // Clear partial progress from localStorage
+  localStorage.removeItem(`quiz1_progress_${getUserId()}_${storyId}`);
 
-  // Store quiz results with badge type
-  sessionStorage.setItem(
-    "quiz1Results",
-    JSON.stringify({
-      score: score,
-      total: quizData.questions.length,
-      percentage: Math.round((score / quizData.questions.length) * 100),
-      badgeType: badgeType,
-      answers: userAnswers,
-    }),
-  );
+  sessionStorage.setItem("quiz1Results", JSON.stringify({
+    score,
+    total: quizData.questions.length,
+    percentage: Math.round((score / quizData.questions.length) * 100),
+    badgeType,
+    answers: userAnswers,
+  }));
 
-  // Save quiz results to database
-  saveQuizResults(badgeType);
-
-  // Go to result page
+  // Await DB save before navigating so the score is committed
+  await saveQuizResults(badgeType);
   window.location.href = `game-result.html?story=${storyId}&quiz=1`;
 }
 
-// Save quiz results to database
 async function saveQuizResults(badgeType) {
   try {
     const { ipcRenderer } = require("electron");
     const currentUser = JSON.parse(localStorage.getItem("currentUser"));
     const storyId = getStoryId();
-
     if (currentUser) {
-      // Save quiz result score only — badge:upgrade in game-result.js handles the badge
       await ipcRenderer.invoke("quiz:save", {
         userId: currentUser.id,
-        storyId: storyId,
+        storyId,
         quizNumber: 1,
-        score: score,
+        score,
         totalQuestions: quizData.questions.length,
-        badgeType: badgeType,
+        badgeType,
       });
-
       console.log(`Quiz 1 results saved (${badgeType})`);
     }
   } catch (error) {
@@ -384,5 +234,4 @@ async function saveQuizResults(badgeType) {
   }
 }
 
-// Initialize when page loads
 window.addEventListener("DOMContentLoaded", loadQuizData);

--- a/app/js/pick-a-word-quiz.js
+++ b/app/js/pick-a-word-quiz.js
@@ -21,31 +21,43 @@ function getUserId() {
   return currentUser?.id || parseInt(localStorage.getItem('lastUserId')) || 'guest';
 }
 
-// Check for saved quiz progress
-function getSavedQuizProgress() {
+// Check for saved quiz progress (from DB)
+async function getSavedQuizProgress() {
   const storyId = getStoryId();
-  const savedProgress = localStorage.getItem(`quiz1_progress_${getUserId()}_${storyId}`);
-  if (savedProgress) {
-    try {
-      return JSON.parse(savedProgress);
-    } catch (e) {
-      console.error('Error parsing saved progress:', e);
-      return null;
-    }
+  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
+  if (!currentUser) return null;
+  try {
+    const { ipcRenderer } = require('electron');
+    const partial = await ipcRenderer.invoke('quiz:getPartial', {
+      userId: currentUser.id,
+      storyId: storyId,
+      quizNumber: 1
+    });
+    return partial; // { partialScore, partialQuestionIndex } or null
+  } catch (e) {
+    console.error('Error getting partial quiz progress:', e);
+    return null;
   }
-  return null;
 }
 
-// Save quiz progress to localStorage
-function saveQuizProgress(questionIndex, score, answers) {
+// Save quiz progress to DB (partial only — does NOT affect score/completion status)
+async function saveQuizProgress(questionIndex, score, answers) {
   const storyId = getStoryId();
-  localStorage.setItem(`quiz1_progress_${getUserId()}_${storyId}`, JSON.stringify({
-    questionIndex: questionIndex,
-    score: score,
-    answers: answers,
-    timestamp: Date.now()
-  }));
-  console.log(`📊 Quiz 1 progress saved - Question ${questionIndex + 1}, Score: ${score}`);
+  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
+  if (!currentUser) return;
+  try {
+    const { ipcRenderer } = require('electron');
+    await ipcRenderer.invoke('quiz:savePartial', {
+      userId: currentUser.id,
+      storyId: storyId,
+      quizNumber: 1,
+      partialScore: score,
+      partialQuestionIndex: questionIndex
+    });
+    console.log(`📊 Quiz 1 partial progress saved to DB - Question ${questionIndex + 1}, Score: ${score}`);
+  } catch (e) {
+    console.error('Error saving partial quiz progress:', e);
+  }
 }
 
 // Show resume modal for quiz
@@ -66,15 +78,15 @@ function hideResumeModal() {
 }
 
 // Resume quiz from saved progress
-function continueGame() {
+async function continueGame() {
   console.log('▶️ Resuming quiz from saved progress');
   hideResumeModal();
   
-  const savedProgress = getSavedQuizProgress();
+  const savedProgress = await getSavedQuizProgress();
   if (savedProgress && quizData) {
-    currentQuestionIndex = savedProgress.questionIndex;
-    score = savedProgress.score;
-    userAnswers = savedProgress.answers;
+    currentQuestionIndex = savedProgress.partialQuestionIndex;
+    score = savedProgress.partialScore;
+    userAnswers = [];
     
     // Show quiz screen
     document.getElementById('quizIntro').style.display = 'none';
@@ -87,12 +99,24 @@ function continueGame() {
 }
 
 // Start quiz again from beginning
-function startAgain() {
+async function startAgain() {
   console.log('🔄 Starting quiz over');
   hideResumeModal();
 
-  const storyId = getStoryId();
-  localStorage.removeItem(`quiz1_progress_${getUserId()}_${storyId}`);
+  // Clear partial progress from DB
+  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
+  if (currentUser) {
+    try {
+      const { ipcRenderer } = require('electron');
+      await ipcRenderer.invoke('quiz:clearPartial', {
+        userId: currentUser.id,
+        storyId: getStoryId(),
+        quizNumber: 1
+      });
+    } catch (e) {
+      console.error('Error clearing partial progress:', e);
+    }
+  }
 
   // Reset state
   currentQuestionIndex = 0;
@@ -127,9 +151,9 @@ async function loadQuizData() {
     document.getElementById("totalQuestions").textContent =
       quizData.questions.length;
 
-    // Check for saved progress
-    const savedProgress = getSavedQuizProgress();
-    if (savedProgress && savedProgress.questionIndex < quizData.questions.length) {
+    // Check for saved partial progress in DB
+    const savedProgress = await getSavedQuizProgress();
+    if (savedProgress && savedProgress.partialQuestionIndex < quizData.questions.length) {
       console.log('🔄 Found saved quiz progress - showing resume modal');
       showQuizResumeModal(savedProgress);
     }
@@ -297,12 +321,24 @@ function calculateBadgeType(score, total) {
 }
 
 // Finish quiz
-function finishQuiz() {
+async function finishQuiz() {
   const badgeType = calculateBadgeType(score, quizData.questions.length);
   const storyId = getStoryId();
 
-  // Clear saved progress since quiz is complete
-  localStorage.removeItem(`quiz1_progress_${getUserId()}_${storyId}`);
+  // Clear partial progress from DB since quiz is complete
+  const currentUser = JSON.parse(localStorage.getItem('currentUser'));
+  if (currentUser) {
+    try {
+      const { ipcRenderer } = require('electron');
+      await ipcRenderer.invoke('quiz:clearPartial', {
+        userId: currentUser.id,
+        storyId: storyId,
+        quizNumber: 1
+      });
+    } catch (e) {
+      console.error('Error clearing partial progress on finish:', e);
+    }
+  }
 
   // Store quiz results with badge type
   sessionStorage.setItem(

--- a/app/js/preloader.js
+++ b/app/js/preloader.js
@@ -1,0 +1,156 @@
+// preloader.js - Shared Image Preloader for All Pages
+// ⚡ Drop this into the <head> of each page BEFORE any other scripts or CSS:
+// <script src="../../assets/js/preloader.js"></script>
+
+(function () {
+
+    // ============================================
+    // EXACT PATHS FROM YOUR CSS FILES
+    // These match what's actually referenced in each page's CSS
+    // ============================================
+    const PAGE_ASSETS = {
+        // welcome-page.css → url('../assets/images/backgrounds/welcome.svg')
+        'welcome': [
+            '../../assets/images/backgrounds/welcome.svg',
+        ],
+        'welcome-auth': [
+            '../../assets/images/backgrounds/welcome.svg',
+        ],
+
+        // auth.css → url('../assets/images/backgrounds/auth-bg.svg')
+        'login': [
+            '../../assets/images/backgrounds/auth-bg.svg',
+        ],
+        'register': [
+            '../../assets/images/backgrounds/auth-bg.svg',
+        ],
+
+        // stories.css → url('../assets/images/backgrounds/library-bg.png')
+        'library': [
+            '../../assets/images/backgrounds/library-bg.png',
+        ],
+        'personal-library': [
+            '../../assets/images/backgrounds/library-bg.png',
+        ],
+
+        // badge.css → url('../assets/images/backgrounds/library-bg.png')
+        'badges': [
+            '../../assets/images/backgrounds/library-bg.png',
+            '../../assets/images/badges/gold-badge.png',
+            '../../assets/images/badges/silver-badge.png',
+            '../../assets/images/badges/bronze-badge.png',
+            '../../assets/images/badges/locked-badge.png',
+        ],
+
+        // finish-book.css → url('../assets/images/backgrounds/game-bg.svg')
+        'finish-book': [
+            '../../assets/images/backgrounds/game-bg.svg',
+            '../../assets/images/badges/bronze-badge.png',
+        ],
+
+        // game-result.css → url('../assets/images/backgrounds/game-bg.svg')
+        'game-result': [
+            '../../assets/images/backgrounds/game-bg.svg',
+            '../../assets/images/badges/gold-badge.png',
+            '../../assets/images/badges/silver-badge.png',
+            '../../assets/images/badges/bronze-badge.png',
+        ],
+
+        // decode-the-world.css / decode-the-world-game.css → url('../assets/images/backgrounds/game-bg.svg')
+        'decode-the-word': [
+            '../../assets/images/backgrounds/game-bg.svg',
+        ],
+
+        // pick-a-word-quiz.css / pick-a-world.css → url('../assets/images/backgrounds/game-bg.svg')
+        'pick-a-word': [
+            '../../assets/images/backgrounds/game-bg.svg',
+        ],
+
+        // lets-review.css → url('../assets/images/backgrounds/game-bg.svg')
+        'lets-review': [
+            '../../assets/images/backgrounds/game-bg.svg',
+        ],
+    };
+
+    // ============================================
+    // DETECT CURRENT PAGE FROM FILENAME
+    // ============================================
+    function getCurrentPage() {
+        const path = window.location.pathname;
+        return path.split('/').pop().replace('.html', '');
+    }
+
+    // ============================================
+    // INJECT <link rel="preload"> INTO <head>
+    // This is the fastest method — higher browser priority
+    // than new Image(), and crucially it also primes the
+    // cache for CSS background-image (new Image() doesn't)
+    // ============================================
+    function injectPreloadLinks(paths) {
+        paths.forEach(src => {
+            const link = document.createElement('link');
+            link.rel = 'preload';
+            link.as = 'image';
+            link.href = src;
+            document.head.appendChild(link);
+        });
+    }
+
+    // ============================================
+    // PRELOAD PICK-A-WORD QUIZ IMAGES
+    // Fetches story JSON and preloads every question's
+    // image upfront so there's zero wait per question
+    // ============================================
+    async function preloadPickAWordImages() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const storyId = parseInt(
+            urlParams.get('story') ||
+            sessionStorage.getItem('quizStoryId') ||
+            '1'
+        );
+
+        try {
+            const response = await fetch(`../../data/stories/story-${storyId}.json`);
+            if (!response.ok) return;
+
+            const storyData = await response.json();
+            const quiz1 = storyData.quiz1;
+            if (!quiz1 || !quiz1.questions) return;
+
+            const imagePaths = quiz1.questions.map(q => {
+                const correctWord = q.options[q.correctAnswer];
+                return `../../assets/images/pick-a-word/story${storyId}-pick-a-word/${correctWord.toLowerCase().replace(/\s+/g, '')}.png`;
+            });
+
+            console.log(`⚡ Preloading ${imagePaths.length} pick-a-word images for story ${storyId}`);
+            injectPreloadLinks(imagePaths);
+
+        } catch (err) {
+            console.warn('⚠️ Could not preload pick-a-word images:', err.message);
+        }
+    }
+
+    // ============================================
+    // MAIN — runs immediately when script tag is parsed,
+    // before CSS is applied, so backgrounds are already
+    // in cache by the time they're needed
+    // ============================================
+    function preloadPageAssets() {
+        const page = getCurrentPage();
+        console.log(`⚡ Preloader running for page: ${page}`);
+
+        const knownAssets = PAGE_ASSETS[page] || [];
+        if (knownAssets.length > 0) {
+            injectPreloadLinks(knownAssets);
+            console.log(`⚡ Preloaded ${knownAssets.length} assets for "${page}"`);
+        }
+
+        // Pick-a-word needs dynamic image preloading from story JSON
+        if (page === 'pick-a-word') {
+            preloadPickAWordImages(); // async, non-blocking
+        }
+    }
+
+    preloadPageAssets();
+
+})();

--- a/app/pages/dashboard/badges.html
+++ b/app/pages/dashboard/badges.html
@@ -8,6 +8,7 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <script src="../../assets/js/preloader.js"></script>
     <link
         href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">

--- a/app/pages/dashboard/decode-the-word.html
+++ b/app/pages/dashboard/decode-the-word.html
@@ -7,6 +7,7 @@
     <title>Decode the Word - VocabVenture</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <script src="../../assets/js/preloader.js"></script>
     <link
         href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">

--- a/app/pages/dashboard/finish-book.html
+++ b/app/pages/dashboard/finish-book.html
@@ -7,6 +7,7 @@
     <title>Story Complete - VocabVenture</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <script src="../../assets/js/preloader.js"></script>
     <link
         href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">

--- a/app/pages/dashboard/game-result.html
+++ b/app/pages/dashboard/game-result.html
@@ -7,6 +7,7 @@
     <title>Quiz Results - VocabVenture</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <script src="../../assets/js/preloader.js"></script>
     <link
         href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">

--- a/app/pages/dashboard/lets-review.html
+++ b/app/pages/dashboard/lets-review.html
@@ -7,6 +7,7 @@
     <title>Vocabulary Review - VocabVenture</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <script src="../../assets/js/preloader.js"></script>
     <link
         href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">

--- a/app/pages/dashboard/pick-a-word.html
+++ b/app/pages/dashboard/pick-a-word.html
@@ -7,6 +7,7 @@
     <title>Pic-a-Word Quiz - VocabVenture</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <script src="../../assets/js/preloader.js"></script>
     <link
         href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">

--- a/app/pages/dashboard/welcome-auth.html
+++ b/app/pages/dashboard/welcome-auth.html
@@ -6,6 +6,7 @@
     <title>Welcome - VocabVenture</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <script src="../../assets/js/preloader.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../css/main.css">
     <link rel="stylesheet" href="../../css/components.css">

--- a/app/pages/dashboard/welcome.html
+++ b/app/pages/dashboard/welcome.html
@@ -6,6 +6,7 @@
     <title>VocabVenture - Welcome</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <script src="../../assets/js/preloader.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../css/main.css">
     <link rel="stylesheet" href="../../css/auth.css">

--- a/index.js
+++ b/index.js
@@ -460,3 +460,41 @@ process.on('uncaughtException', (error) => {
 process.on('unhandledRejection', (error) => {
     console.error('Unhandled rejection:', error);
 });
+
+// ============================================
+// ADD THESE THREE HANDLERS TO index.js
+// (alongside your existing quiz:save handler)
+// ============================================
+
+// Save partial quiz progress mid-quiz (does NOT affect completion status or score)
+ipcMain.handle('quiz:savePartial', async (event, { userId, storyId, quizNumber, partialScore, partialQuestionIndex }) => {
+    try {
+        db.savePartialQuizProgress(userId, storyId, quizNumber, partialScore, partialQuestionIndex);
+        return { success: true };
+    } catch (error) {
+        console.error('Error saving partial quiz progress:', error);
+        return { success: false, error: error.message };
+    }
+});
+
+// Get partial quiz progress for resume modal
+ipcMain.handle('quiz:getPartial', async (event, { userId, storyId, quizNumber }) => {
+    try {
+        const partial = db.getPartialQuizProgress(userId, storyId, quizNumber);
+        return partial; // { partialScore, partialQuestionIndex } or null
+    } catch (error) {
+        console.error('Error getting partial quiz progress:', error);
+        return null;
+    }
+});
+
+// Clear partial quiz progress (called on finish or start-over)
+ipcMain.handle('quiz:clearPartial', async (event, { userId, storyId, quizNumber }) => {
+    try {
+        db.clearPartialQuizProgress(userId, storyId, quizNumber);
+        return { success: true };
+    } catch (error) {
+        console.error('Error clearing partial quiz progress:', error);
+        return { success: false, error: error.message };
+    }
+});


### PR DESCRIPTION
## perf: fix library loading lag, quiz resume bugs, and image preloading

## Problem

Several screens suffered from noticeable lag, and one bug caused progress bars to show incorrect completion state after pressing home mid-quiz:

- **Library loaded blank for ~30 round-trips** — `loadProgress()` awaited 30 IPC calls sequentially before rendering anything
- **Story viewer video lag** — each segment loaded cold on navigation with no lookahead
- **Background images flashed in late** — game, welcome, and result pages had no preloading strategy
- **Progress bar reset to 0% on genre switch** — `applyProgressBars()` wasn't called after each `renderLibrary()`
- **Progress bar flickered before cover art** — bar appeared immediately while the book cover was still loading
- **Resuming mid-quiz replayed the last answered question** — partial progress was saved with the current index, not the next one
- **Resume modal showed NaN** — log still read `questionIndex` after field was renamed to `partialQuestionIndex`
- **Fast navigation after quiz finish could miss DB write** — `finishQuiz` navigated before `saveQuizResults` resolved

## Solution

### `library.js` / `personal-library.js`
- **`loadProgress()`** — Replaced sequential `await` loop with `Promise.all()`. All IPC calls now fire in parallel, cutting wait time from `30 × latency` to `1 × latency`
- **`renderLibrary()`** — Now calls `applyProgressBars()` on every invocation. Previously only ran on initial load, so genre switches and search wiped all progress bars
- **`renderBook()`** — Progress bar starts at `opacity: 0` and fades in (0.3s) only after the cover image's `onload` fires
- Added `<link rel="preload">` hints for cover images immediately after the stories index loads
- Shows a "Loading..." placeholder immediately so the library isn't blank during IPC resolution

### `story-viewer.js`
- When a segment starts playing, the next segment's video is fetched into a blob URL in the background. On Next, the blob URL is assigned directly to `<source>` — no file lookup, near-instant playback
- Blob URLs are revoked after use via `URL.revokeObjectURL()` to keep memory flat across a full story read

### `preloader.js` *(new)*
- Shared preload script added to the `<head>` of game-result, decode-the-word, pick-a-word, finish-book, and welcome pages — fires before any other scripts
- Immediately queues all known background and badge assets as `<link rel="preload">` tags. Paths sourced directly from the existing CSS files
- After DOM load, scans computed styles to catch any backgrounds not in the static list

### `decode-the-word-quiz.js` / `pick-a-word-quiz.js`
- Partial progress fields renamed from `questionIndex`/`score` to `partialQuestionIndex`/`partialScore` to clearly separate in-progress state from completed results
- **`saveQuizProgress()`** — Now saves `currentQuestionIndex + 1` (next unanswered question). Previously, resuming after pressing home replayed the last answered question
- Resume modal log fixed to read `partialQuestionIndex` — was displaying `NaN`
- **`finishQuiz()`** — Now `async`, awaits the DB write before navigating so the score row is always committed before the library's completion query runs

### `database.js`
- **`getStoryCompletionStatus()`** and **`getBestQuizScore()`** — Both now include `AND score IS NOT NULL` so null or partial rows can never register as a completed quiz in progress bar calculations

## Testing

- [x] Press home mid-quiz → resume modal shows correct next question, not a replayed one
- [x] Press home mid-quiz → return to library → progress bar reflects DB state only
- [x] Pass a quiz with a perfect score → progress bar and badge update before library loads
- [x] Switch genres in library → progress bars persist, do not reset to 0%
- [x] Open any game or welcome page → background images load without visible lag on first visit
- [x] Book cover loads → progress bar fades in after the art, not before